### PR TITLE
more cocoa butter

### DIFF
--- a/css/blessup.css
+++ b/css/blessup.css
@@ -134,6 +134,7 @@ p {
 #select-style select {
   display: block;
   width: 100%;
+  height: 100%;
   margin: 0;
   padding-left: 16px;
   -webkit-appearance: none;


### PR DESCRIPTION
yo so the `select` element looked mad funky on mozilla and chrome. setting `height: 100%;` was a major key to success. bless up.
